### PR TITLE
feat: add convenience function for adding multiple routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ middleware, error handling, api fields / returning extraction).
 
 ```typescript
 import * as Router from 'koa-router';
-import { route, addRouteToRouter, HttpMethod } from '@lcdev/router';
+import { route, addRouteToRouter, addRoutesToRouter, HttpMethod } from '@lcdev/router';
 
 const router = new Router();
 
@@ -505,6 +505,21 @@ addRouteToRouter(
   }),
   router,
 );
+
+// or
+
+addRoutesToRouter(router, [
+  route({
+    path: '/my-route',
+    method: HttpMethod.GET,
+    async action() {
+      return {
+        foo: 'bar',
+        bar: 'baz',
+      };
+    },
+  }),
+]);
 
 export default router;
 ```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   bindRouteActions,
   createAllRoutes,
   addRouteToRouter,
+  addRoutesToRouter,
   createOpenAPI,
   propagateErrors,
   propagateValues,
@@ -1438,6 +1439,45 @@ test('addRouteToRouter', async () => {
     .get('/my-route')
     .expect(200)
     .expect({ foo: 'bar' });
+
+  server.close();
+});
+
+test('addRoutesToRouter', async () => {
+  const app = new Koa();
+  const router = new Router();
+
+  addRoutesToRouter(router, [
+    route({
+      path: '/first',
+      method: HttpMethod.GET,
+      async action() {
+        return 'first';
+      },
+    }),
+    route({
+      path: '/second',
+      method: HttpMethod.GET,
+      async action() {
+        return 'second';
+      },
+    }),
+  ]);
+
+  app.use(router.routes()).use(router.allowedMethods());
+
+  const server = createServer(app.callback());
+  const test = agent(server);
+
+  await test
+    .get('/first')
+    .expect(200)
+    .expect('first');
+
+  await test
+    .get('/second')
+    .expect(200)
+    .expect('second');
 
   server.close();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -721,6 +721,13 @@ export const addRouteToRouter = (route: Route | MadeRoute, router: Router) => {
   });
 };
 
+export const addRoutesToRouter = (router: Router, routes: (Route | MadeRoute)[]) => {
+  for (const route of routes) {
+    addRouteToRouter(route, router);
+  }
+  return router;
+};
+
 function filterInternalMessages(
   status: number,
   errorMessage: string,


### PR DESCRIPTION
this just adds a convenience function for adding multiple routes in a single function call.

rather than:

```
addRouteToRouter(...);
addRouteToRouter(...);
addRouteToRouter(...);
```

you can just do:

```
addRoutesToRouter(router, [
...
])
```